### PR TITLE
Generating all 4 lineup formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "sunday-service-vr",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -15,7 +15,7 @@
                 "@types/node": "^16.11.41",
                 "@types/react": "^18.0.14",
                 "@types/react-dom": "^18.0.5",
-                "dayjs": "^1.11.3",
+                "dayjs": "^1.11.10",
                 "react": "^18.2.0",
                 "react-datepicker": "^4.8.0",
                 "react-dom": "^18.2.0",
@@ -6236,9 +6236,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-            "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
+            "version": "1.11.10",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+            "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
         },
         "node_modules/debug": {
             "version": "4.3.4",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -11,7 +11,7 @@
         "@types/node": "^16.11.41",
         "@types/react": "^18.0.14",
         "@types/react-dom": "^18.0.5",
-        "dayjs": "^1.11.3",
+        "dayjs": "^1.11.10",
         "react": "^18.2.0",
         "react-datepicker": "^4.8.0",
         "react-dom": "^18.2.0",

--- a/webapp/src/components/EventDetails.tsx
+++ b/webapp/src/components/EventDetails.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Button, Card, CardBody, CardFooter, CardHeader, Form, Tabs, Tab} from "react-bootstrap";
 import { Event, Slot } from "../util/types";
+import EventPasteCard from "./EventPasteCard";
 
 
 type Props = {
@@ -66,30 +67,30 @@ const getSlotText = (slot: Slot) => {
 const EventDetails = ({ event }: Props) => {
 
     const discordMessage = getDiscordMessage(event);
+    const twitterMessage = getTwitterMessage(event);
+    const ukMessage = getUkPasteMessage(event);
+    const ausMessage = getAusPasteMessage(event);
 
-    return <Card>
-            <Tabs className="">
+    return <div>
+
+            <Tabs className="mt-4">
                 <Tab eventKey="discord" title="Discord">
-                    <CardBody>
-                        <Form.Control as="textarea" value={discordMessage} rows={16} readOnly className="has-fixed-size" />
-                    </CardBody>
-                    <CardFooter className="d-grid gap-2">
-                        <Button color={"primary"} onClick={() => { navigator.clipboard.writeText(discordMessage); }}>Copy Text</Button>
-                    </CardFooter>
+                    <EventPasteCard event={event} message={discordMessage}></EventPasteCard>
                 </Tab>
                 <Tab eventKey="twitter" title="Twitter">
-                    Tab content for Twitter
+                    <EventPasteCard event={event} message={twitterMessage}></EventPasteCard>
                 </Tab>
                 <Tab eventKey="uk" title="UK Paste">
-                    Tab content for UK
+                    <EventPasteCard event={event} message={ukMessage}></EventPasteCard>
                 </Tab>
                 <Tab eventKey="au" title="AU Paste">
-                    Tab content for AU
+                    <EventPasteCard event={event} message={ausMessage}></EventPasteCard>
+
                 </Tab>
             </Tabs>
             {/* <Message color="warning" size="small" className="p-3 m-2">Still need to implement a little toast message when ya copy, sorry, just trying to get this out the door :x</Message> */}
             
-        </Card>
+        </div>
 };
 
 export default EventDetails;

--- a/webapp/src/components/EventDetails.tsx
+++ b/webapp/src/components/EventDetails.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Card, CardBody, CardFooter, CardHeader, Form, } from "react-bootstrap";
+import { Button, Card, CardBody, CardFooter, CardHeader, Form, Tabs, Tab } from "react-bootstrap";
 import { Event, Slot } from "../util/types";
 
 
@@ -37,6 +37,20 @@ const EventDetails = ({ event }: Props) => {
     return <Card>
             <CardHeader>Discord Message</CardHeader>
             <CardBody>
+                <Tabs>
+                    <Tab eventKey="discord" title="Discord">
+                        Tab content for Discord
+                    </Tab>
+                    <Tab eventKey="twitter" title="Twitter">
+                        Tab content for Twitter
+                    </Tab>
+                    <Tab eventKey="uk" title="UK Paste">
+                        Tab content for UK
+                    </Tab>
+                    <Tab eventKey="au" title="AU Paste">
+                        Tab content for AU
+                    </Tab>
+                </Tabs>
                 <Form.Control as="textarea" value={eventMessage} rows={16} readOnly className="has-fixed-size" />
             </CardBody>
             <CardFooter className="d-grid gap-2">

--- a/webapp/src/components/EventDetails.tsx
+++ b/webapp/src/components/EventDetails.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { Button, Card, CardBody, CardFooter, CardHeader, Form, Tabs, Tab } from "react-bootstrap";
+import { Button, Card, CardBody, CardFooter, CardHeader, Form, Nav} from "react-bootstrap";
 import { Event, Slot } from "../util/types";
 
 
 type Props = {
     event: Event
 };
+
 
 const getDiscordMessage = (event: Event): string => 
 `${event.name}
@@ -16,10 +17,42 @@ DJs:
 ${event.slots.map(getSlotText).join("\n")}
 `;
 
+
+const getTwitterMessage = (event: Event): string =>
+`${event.name}
+${event.message}
+Twitter Test
+
+DJs:
+${event.slots.map(getSlotText).join("\n")}
+`;
+
+
+const getUkPasteMessage = (event: Event): string =>
+`${event.name}
+${event.message}
+UK Test
+
+DJs:
+${event.slots.map(getSlotText).join("\n")}
+`;
+
+
+const getAusPasteMessage = (event: Event): string =>
+`${event.name}
+${event.message}
+Australia Test
+
+DJs:
+${event.slots.map(getSlotText).join("\n")}
+`;
+
+
 const dateToDiscordTime = (date: Date): string => {
     // Example: <t:1656270000:R>
     return `<t:${Math.floor(date.getTime() / 1000)}>`;
 }
+
 
 const getSlotText = (slot: Slot) => {
     let slotText = `${slot.startTime ? dateToDiscordTime(slot.startTime) : ""} : ${slot.dj.name}`;
@@ -34,23 +67,32 @@ const EventDetails = ({ event }: Props) => {
 
     const eventMessage = getDiscordMessage(event);
 
+    // const setDiscordMessage = () => {eventMessage = getDiscordMessage(event); console.log("Discord")}
+    // const setTwitterMessage = () => {eventMessage = getTwitterMessage(event); console.log("Twitter")}
+
+    const handleSelect = (activeKey : any) => {
+        if (activeKey === "discord") console.log("Discord");
+        else if (activeKey === "twitter") console.log("Twitter");
+        else return ;
+    }
+
     return <Card>
             <CardHeader>Discord Message</CardHeader>
             <CardBody>
-                <Tabs>
-                    <Tab eventKey="discord" title="Discord">
-                        Tab content for Discord
-                    </Tab>
-                    <Tab eventKey="twitter" title="Twitter">
-                        Tab content for Twitter
-                    </Tab>
-                    <Tab eventKey="uk" title="UK Paste">
-                        Tab content for UK
-                    </Tab>
-                    <Tab eventKey="au" title="AU Paste">
-                        Tab content for AU
-                    </Tab>
-                </Tabs>
+                <Nav variant="tabs" defaultActiveKey="discord" onSelect={handleSelect}>
+                    <Nav.Item>
+                        <Nav.Link eventKey="discord">Discord</Nav.Link>
+                    </Nav.Item>
+                    <Nav.Item>
+                        <Nav.Link eventKey="twitter">Twitter</Nav.Link>
+                    </Nav.Item>
+                    <Nav.Item>
+                        <Nav.Link eventKey="uk">UK Paste</Nav.Link>
+                    </Nav.Item>
+                    <Nav.Item>
+                        <Nav.Link eventKey="au">AU Paste</Nav.Link>
+                    </Nav.Item>
+                </Nav>
                 <Form.Control as="textarea" value={eventMessage} rows={16} readOnly className="has-fixed-size" />
             </CardBody>
             <CardFooter className="d-grid gap-2">

--- a/webapp/src/components/EventDetails.tsx
+++ b/webapp/src/components/EventDetails.tsx
@@ -11,41 +11,45 @@ type Props = {
 
 const getDiscordMessage = (event: Event): string => 
 `${event.name}
+
 ${event.message}
-${dateToDiscordTime(event.start_datetime)}
+
+Event start: ${dateToDiscordTime(event.start_datetime)}
+
+Host: ${event.host}
 
 DJs:
-${event.slots.map(getSlotText).join("\n")}
+${event.slots.map(getDiscordSlotText).join("\n")}
 `;
 
 
 const getTwitterMessage = (event: Event): string =>
 `${event.name}
-${event.message}
-Twitter Test
+${event.start_datetime.toISOString().split('T')[0]}
+Host: ${event.host}
 
-DJs:
-${event.slots.map(getSlotText).join("\n")}
+Lineup: (times GMT)
+${event.slots.map(getPasteSlotText).join("\n")}
 `;
 
 
 const getUkPasteMessage = (event: Event): string =>
 `${event.name}
-${event.message}
-UK Test
+${event.start_datetime.toISOString().split('T')[0]}
+Host: ${event.host}
 
-DJs:
-${event.slots.map(getSlotText).join("\n")}
+Lineup: (times GMT)
+${event.slots.map(getPasteSlotText).join("\n")}
 `;
 
 
 const getAusPasteMessage = (event: Event): string =>
 `${event.name}
-${event.message}
-Australia Test
+${event.start_datetime.toISOString().split('T')[0]}
+Host: ${event.host}
 
-DJs:
-${event.slots.map(getSlotText).join("\n")}
+Lineup: (times are NOT RIGHT!!!!!!!! [to-do])
+${event.slots.map(getPasteSlotText).join("\n")}
 `;
 
 
@@ -54,12 +58,21 @@ const dateToDiscordTime = (date: Date): string => {
     return `<t:${Math.floor(date.getTime() / 1000)}>`;
 }
 
+const dateToPasteTime = (date : Date): string => {
+    return date.toLocaleString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true });
+}
 
-const getSlotText = (slot: Slot) => {
+
+const getDiscordSlotText = (slot: Slot): string => {
     let slotText = `${slot.startTime ? dateToDiscordTime(slot.startTime) : ""} : ${slot.dj.name}`;
     if(slot.dj.twitch_url) {
         slotText = `${slotText} - ${slot.dj.twitch_url}`
     }
+    return slotText;
+}
+
+const getPasteSlotText = (slot : Slot): string => {
+    let slotText = `${slot.dj.name} - ${slot.startTime ? dateToPasteTime(slot.startTime) : ""}`;
     return slotText;
 }
 

--- a/webapp/src/components/EventDetails.tsx
+++ b/webapp/src/components/EventDetails.tsx
@@ -11,16 +11,19 @@ type Props = {
 
 
 const getDiscordMessage = (event: Event): string => 
-`${event.name}
+`**${event.name}**
 
 ${event.message}
 
-Event start: ${dateToDiscordTime(event.start_datetime)}
+Event start: ${dateToDiscordTime(event.start_datetime).replace(">",":F>")}
 
 Host: ${event.host}
 
 DJs:
 ${event.slots.map(getDiscordSlotText).join("\n")}
+
+https://discord.s4vr.net/
+https://twitch.s4vr.net/
 `;
 
 
@@ -32,7 +35,9 @@ Host: ${event.host}
 
 Lineup: (times ${ukDayTz.format('z')
                         .replace("GMT+1","BST")})
-${event.slots.map(getUkPasteSlotText).join("\n")}
+${event.slots.map(getTwitterSlotText).join("\n")}
+
+https://twitch.s4vr.net/
 `;
 }
 
@@ -45,7 +50,7 @@ Host: ${event.host}
 
 Lineup: (times ${ukDayTz.format('z')
                         .replace("GMT+1","BST")})
-${event.slots.map(getUkPasteSlotText).join("\n")}
+${event.slots.map(getUkSlotText).join("\n")}
 `;
 }
 
@@ -59,7 +64,7 @@ Host: ${event.host}
 Lineup: (times ${ausDayTz.format('z')
                         .replace("GMT+11","AEDT")
                         .replace("GMT+10","AEST")})
-${event.slots.map(getAusPasteSlotText).join("\n")}
+${event.slots.map(getAusSlotText).join("\n")}
 `;
 }
 
@@ -70,34 +75,34 @@ const dateToDiscordTime = (date: Date): string => {
 }
 
 
+const dateToLineupTime = (date: Date, timezone : string): string => {
+    return `${dayjs.tz(date, timezone).format('h:mma')
+                                      .slice(0,-1)
+                                      .replace(":00", "")}`;
+}
+
+
 const getDiscordSlotText = (slot: Slot): string => {
     let slotText = `${slot.startTime ? dateToDiscordTime(slot.startTime) : ""} : ${slot.dj.name}`;
-    if(slot.dj.twitch_url) {
-        slotText = `${slotText} - ${slot.dj.twitch_url}`
-    }
     return slotText;
 }
 
 
-const getUkPasteSlotText = (slot : Slot): string => {
-    let slotText = `${slot.startTime ? dateToUkPasteTime(slot.startTime) : ""} ${slot.dj.name}`;
+const getTwitterSlotText = (slot : Slot): string => {
+    let slotText = `${slot.startTime ? dateToLineupTime(slot.startTime, "Europe/London") : ""} - ${slot.dj.name}`;
     return slotText;
 }
 
 
-const getAusPasteSlotText = (slot : Slot): string => {
-    let slotText = `${slot.startTime ? dateToAusPasteTime(slot.startTime) : ""} ${slot.dj.name}`;
+const getUkSlotText = (slot : Slot): string => {
+    let slotText = `${slot.startTime ? dateToLineupTime(slot.startTime, "Europe/London") : ""} ${slot.dj.name}`;
     return slotText;
 }
 
 
-const dateToUkPasteTime = (date : Date): string => {
-    return `${dayjs.tz(date, "Europe/London").format('h:mma').slice(0,-1)}`;
-}
-
-
-const dateToAusPasteTime = (date : Date): string => {
-    return `${dayjs.tz(date, "Australia/Sydney").format('h:mma').slice(0,-1)}`;
+const getAusSlotText = (slot : Slot): string => {
+    let slotText = `${slot.startTime ? dateToLineupTime(slot.startTime, "Australia/Sydney") : ""} ${slot.dj.name}`;
+    return slotText;
 }
 
 

--- a/webapp/src/components/EventDetails.tsx
+++ b/webapp/src/components/EventDetails.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Card, CardBody, CardFooter, CardHeader, Form, Nav} from "react-bootstrap";
+import { Button, Card, CardBody, CardFooter, CardHeader, Form, Tabs, Tab} from "react-bootstrap";
 import { Event, Slot } from "../util/types";
 
 
@@ -65,41 +65,30 @@ const getSlotText = (slot: Slot) => {
 
 const EventDetails = ({ event }: Props) => {
 
-    const eventMessage = getDiscordMessage(event);
-
-    // const setDiscordMessage = () => {eventMessage = getDiscordMessage(event); console.log("Discord")}
-    // const setTwitterMessage = () => {eventMessage = getTwitterMessage(event); console.log("Twitter")}
-
-    const handleSelect = (activeKey : any) => {
-        if (activeKey === "discord") console.log("Discord");
-        else if (activeKey === "twitter") console.log("Twitter");
-        else return ;
-    }
+    const discordMessage = getDiscordMessage(event);
 
     return <Card>
-            <CardHeader>Discord Message</CardHeader>
-            <CardBody>
-                <Nav variant="tabs" defaultActiveKey="discord" onSelect={handleSelect}>
-                    <Nav.Item>
-                        <Nav.Link eventKey="discord">Discord</Nav.Link>
-                    </Nav.Item>
-                    <Nav.Item>
-                        <Nav.Link eventKey="twitter">Twitter</Nav.Link>
-                    </Nav.Item>
-                    <Nav.Item>
-                        <Nav.Link eventKey="uk">UK Paste</Nav.Link>
-                    </Nav.Item>
-                    <Nav.Item>
-                        <Nav.Link eventKey="au">AU Paste</Nav.Link>
-                    </Nav.Item>
-                </Nav>
-                <Form.Control as="textarea" value={eventMessage} rows={16} readOnly className="has-fixed-size" />
-            </CardBody>
-            <CardFooter className="d-grid gap-2">
-                <Button color={"primary"} onClick={() => { navigator.clipboard.writeText(eventMessage); }}>Copy Text</Button>
-
-            </CardFooter>
+            <Tabs className="">
+                <Tab eventKey="discord" title="Discord">
+                    <CardBody>
+                        <Form.Control as="textarea" value={discordMessage} rows={16} readOnly className="has-fixed-size" />
+                    </CardBody>
+                    <CardFooter className="d-grid gap-2">
+                        <Button color={"primary"} onClick={() => { navigator.clipboard.writeText(discordMessage); }}>Copy Text</Button>
+                    </CardFooter>
+                </Tab>
+                <Tab eventKey="twitter" title="Twitter">
+                    Tab content for Twitter
+                </Tab>
+                <Tab eventKey="uk" title="UK Paste">
+                    Tab content for UK
+                </Tab>
+                <Tab eventKey="au" title="AU Paste">
+                    Tab content for AU
+                </Tab>
+            </Tabs>
             {/* <Message color="warning" size="small" className="p-3 m-2">Still need to implement a little toast message when ya copy, sorry, just trying to get this out the door :x</Message> */}
+            
         </Card>
 };
 

--- a/webapp/src/components/EventDetails.tsx
+++ b/webapp/src/components/EventDetails.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Button, Card, CardBody, CardFooter, CardHeader, Form, Tabs, Tab} from "react-bootstrap";
 import { Event, Slot } from "../util/types";
 import EventPasteCard from "./EventPasteCard";
+import dayjs from "dayjs";
 
 
 type Props = {
@@ -23,43 +24,49 @@ ${event.slots.map(getDiscordSlotText).join("\n")}
 `;
 
 
-const getTwitterMessage = (event: Event): string =>
-`${event.name}
-${event.start_datetime.toISOString().split('T')[0]}
+const getTwitterMessage = (event: Event): string => {
+    const ukDayTz = dayjs.tz(event.start_datetime, "GB");
+return `${event.name}
+${ukDayTz.format("YYYY-MM-DD")}
 Host: ${event.host}
 
-Lineup: (times GMT)
-${event.slots.map(getPasteSlotText).join("\n")}
+Lineup: (times ${ukDayTz.format('z')
+                        .replace("GMT+1","BST")})
+${event.slots.map(getUkPasteSlotText).join("\n")}
 `;
+}
 
 
-const getUkPasteMessage = (event: Event): string =>
-`${event.name}
-${event.start_datetime.toISOString().split('T')[0]}
+const getUkPasteMessage = (event: Event): string => {
+    const ukDayTz = dayjs.tz(event.start_datetime, "GB");
+return `${event.name}
+${ukDayTz.format("YYYY-MM-DD")}
 Host: ${event.host}
 
-Lineup: (times GMT)
-${event.slots.map(getPasteSlotText).join("\n")}
+Lineup: (times ${ukDayTz.format('z')
+                        .replace("GMT+1","BST")})
+${event.slots.map(getUkPasteSlotText).join("\n")}
 `;
+}
 
 
-const getAusPasteMessage = (event: Event): string =>
-`${event.name}
-${event.start_datetime.toISOString().split('T')[0]}
+const getAusPasteMessage = (event: Event): string =>{
+    const ausDayTz = dayjs.tz(event.start_datetime, "Australia/Sydney");
+    return `${event.name}
+${ausDayTz.format("YYYY-MM-DD")}
 Host: ${event.host}
 
-Lineup: (times are NOT RIGHT!!!!!!!! [to-do])
-${event.slots.map(getPasteSlotText).join("\n")}
+Lineup: (times ${ausDayTz.format('z')
+                        .replace("GMT+11","AEDT")
+                        .replace("GMT+10","AEST")})
+${event.slots.map(getAusPasteSlotText).join("\n")}
 `;
+}
 
 
 const dateToDiscordTime = (date: Date): string => {
     // Example: <t:1656270000:R>
     return `<t:${Math.floor(date.getTime() / 1000)}>`;
-}
-
-const dateToPasteTime = (date : Date): string => {
-    return date.toLocaleString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true });
 }
 
 
@@ -71,9 +78,26 @@ const getDiscordSlotText = (slot: Slot): string => {
     return slotText;
 }
 
-const getPasteSlotText = (slot : Slot): string => {
-    let slotText = `${slot.dj.name} - ${slot.startTime ? dateToPasteTime(slot.startTime) : ""}`;
+
+const getUkPasteSlotText = (slot : Slot): string => {
+    let slotText = `${slot.startTime ? dateToUkPasteTime(slot.startTime) : ""} ${slot.dj.name}`;
     return slotText;
+}
+
+
+const getAusPasteSlotText = (slot : Slot): string => {
+    let slotText = `${slot.startTime ? dateToAusPasteTime(slot.startTime) : ""} ${slot.dj.name}`;
+    return slotText;
+}
+
+
+const dateToUkPasteTime = (date : Date): string => {
+    return `${dayjs.tz(date, "Europe/London").format('h:mma').slice(0,-1)}`;
+}
+
+
+const dateToAusPasteTime = (date : Date): string => {
+    return `${dayjs.tz(date, "Australia/Sydney").format('h:mma').slice(0,-1)}`;
 }
 
 

--- a/webapp/src/components/EventPasteCard.tsx
+++ b/webapp/src/components/EventPasteCard.tsx
@@ -1,0 +1,20 @@
+import { Button, Card, CardBody, CardFooter, CardHeader, Form, Tabs, Tab} from "react-bootstrap";
+import { Event, Slot } from "../util/types";
+
+type Props = {
+    event: Event,
+    message : string
+};
+
+const EventPasteCard = ({ event, message }: Props) => {
+    return <Card>
+        <CardBody>
+            <Form.Control as="textarea" value={message} rows={16} readOnly className="has-fixed-size" />
+        </CardBody>
+        <CardFooter className="d-grid gap-2">
+            <Button color={"primary"} onClick={() => { navigator.clipboard.writeText(message); }}>Copy Text</Button>
+        </CardFooter>
+    </Card>;
+};
+
+export default EventPasteCard;

--- a/webapp/src/components/EventSetup.tsx
+++ b/webapp/src/components/EventSetup.tsx
@@ -52,19 +52,30 @@ const EventForm = ({ djEvent, setEvent, resetEvent }: Props) => {
                         }}
                         className="input" />
         
-            </Form.Group>
-            <Form.Group>
-                <Form.Label>
-                    Message
-                </Form.Label>
-             
-                <Form.Control
-                    type="textarea"
-                    value={djEvent.message}
-                    onChange={(event) => {
-                        setEvent({ ...djEvent, message: event.target.value })
-                    }} />
-            </Form.Group>
+                </Form.Group>
+                <Form.Group>
+                    <Form.Label>
+                        Discord Message
+                    </Form.Label>
+                
+                    <Form.Control
+                        type="textarea"
+                        value={djEvent.message}
+                        onChange={(event) => {
+                            setEvent({ ...djEvent, message: event.target.value })
+                        }} />
+                </Form.Group>
+                <Form.Group>
+                    <Form.Label>
+                        Host
+                    </Form.Label>
+                    <Form.Control
+                        placeholder="Strawbs"
+                        type="text"
+                        value={djEvent.host}
+                        onChange={(event) => { setEvent({ ...djEvent, host: event.target.value }); }}
+                    />
+                </Form.Group>
             </Form>
         </div>
         < hr />

--- a/webapp/src/store/events.tsx
+++ b/webapp/src/store/events.tsx
@@ -18,6 +18,7 @@ export const loadEvent = () => {
 export const default_event: Event = {
     name: "Sunday Service",
     start_datetime: nextSundayServiceDefaultDateTime(),
+    host: "Strawbs",
     message: "Come by to chill and wiggle to some Sunday Service tunes!",
     slots: [],
 }

--- a/webapp/src/store/resident_djs.ts
+++ b/webapp/src/store/resident_djs.ts
@@ -12,11 +12,11 @@ export const RESIDENT_DJS: { [key: string]: Dj } = {
         twitch_url: "https://www.twitch.com/kazzdoggo",
     },
     "icedog": {
-        name: "icedog26",
+        name: "Icedog",
         twitch_url: "https://www.twitch.com/icedog26",
     },
     "whitty": {
-        name: "whitty",
+        name: "Whitty",
         twitch_url: "https://www.twitch.com/WhittyCat",
     },
     "bleatr": {
@@ -24,16 +24,12 @@ export const RESIDENT_DJS: { [key: string]: Dj } = {
         twitch_url: "https://www.twitch.com/bleatrbeats",
     },
     "schlick": {
-        name: "schlick",
+        name: "Schlick",
         twitch_url: "https://www.twitch.tv/schlick_wolf",
     },
     "kittz": {
-        name: "kittz",
+        name: "Kittz",
         twitch_url: "https://www.twitch.com/kittzbeatz",
-    },
-    "forresthusky": {
-        name: "Forrest Husky",
-        twitch_url: "https://www.twitch.com/forresthusky",
     },
     "warned1": {
         name: "WarneD1",

--- a/webapp/src/util/types.ts
+++ b/webapp/src/util/types.ts
@@ -17,6 +17,7 @@ export type Event = {
     name: string;
     message: string;
     start_datetime: Date;
+    host: string;
     slots: Slot[];
 }
 

--- a/webapp/src/util/util.ts
+++ b/webapp/src/util/util.ts
@@ -2,11 +2,14 @@
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
+import advancedFormat from "dayjs/plugin/advancedFormat"
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(advancedFormat);
 
 // God forgive these sins
+// i forgive u bc i did worse -frosty
 export const nextSundayServiceDefaultDateTime = (): Date => {
     let today = new Date();
     let targetDay = new Date();


### PR DESCRIPTION
Some notes:

* Need to incorporate footer field into the discord format box - this branch currently hardcodes the footer
* There's gonna be a conflict between the two different formats for where the announcement text goes

In my opinion, I think seeing the text of the full announcement live-update on the right side of the screen is useful, and gives context for what you're filling out in the form. But you can go ahead and make the final call on that one